### PR TITLE
Update - les types complexes ne sont pas une nouveauté de la version 12

### DIFF
--- a/docs/markdown/langages/00-TITLE.md
+++ b/docs/markdown/langages/00-TITLE.md
@@ -44,7 +44,6 @@ La version 0.12 de terraform introduit de nouveaux types d’objets comme :
 * Nombre
 * Booléen
 * Structure anonyme (object)
-* Type complexe (list de map, map de list, map de map de map, …)
 
 
 ##==##


### PR DESCRIPTION
Suppression de la mention des types complexes.
Les listes de map et listes de listes sont utilisables depuis (au moins) la version 11.