### PR TITLE
step 05 - typo in the kitchen config

### DIFF
--- a/steps/05-testing-strategies/README.md
+++ b/steps/05-testing-strategies/README.md
@@ -94,7 +94,7 @@ suites:
       - name: local
         backend: gcp
         attrs_outputs:
-          project_id: project_id
+          gcp_project_id: project_id
 ```
 
 The `project_id` output from terraform will be mapped to inspec input.


### PR DESCRIPTION
With inspec-gcp, after running the command `bundle exec inspec init profile --platform gcp default`, the expected attribute name is `gcp_project_id`.

That commands generates a test skeleton for GCP with a sample test suite in ruby.

The var referring to the _project_id_ is named `gcp_project_id` ini *attributes.yml* and in the sample test suite in *example.rb* ; not `project_id` as stated in the kitchen config.